### PR TITLE
Add a filter for gamestar.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Some plugins for Tiny-Tiny-RSS
  * af_emsvechtewelle (german, http://www.emsvechtewelle.de/)
  * af_foebud (german, http://www.foebud.org/)
  * af_gameone (german, http://www.gameone.de/)
+ * af_gamestar (german, http://www.gamestar.de/)
  * af_golem (german, http://www.golem.de/)
  * af_gulli (german, http://www.gulli.com/)
  * af_heise (german, http://www.heise.de/)

--- a/af_gamestar/init.php
+++ b/af_gamestar/init.php
@@ -1,0 +1,47 @@
+<?php
+class Af_Gamestar extends Plugin {
+
+    private $host;
+
+    function about() {
+        return array(1.0,
+            "Fetch content of gamestar.de feed",
+            "Joschasa");
+    }
+
+    function api_version() {
+        return 2;
+    }
+
+    function init($host) {
+        $this->host = $host;
+
+        $host->add_hook($host::HOOK_ARTICLE_FILTER, $this);
+    }
+
+    function hook_article_filter($article) {
+        if (strpos($article["link"], "gamestar.de") !== FALSE) {
+            $doc = new DOMDocument();
+            @$doc->loadHTML(mb_convert_encoding(fetch_file_contents($article["link"]), 'HTML-ENTITIES', "UTF-8"));
+
+            $basenode = false;
+
+            if ($doc) {
+                $xpath = new DOMXPath($doc);
+                $entries = $xpath->query('(//div[@class="articleBody"])');
+
+                foreach ($entries as $entry) {
+
+                    $basenode = $entry;
+                    break;
+                }
+
+                if ($basenode) {
+                    $article["content"] = $doc->saveXML($basenode);
+                }
+            }
+        }
+        return $article;
+    }
+}
+?>


### PR DESCRIPTION
I would like to see a filter for gamestar.de in this package.
I've basically copied the af_heise plugin and changed the div class in the query.

I think this might be useful for others as well. If you like this, please accept this pull request.